### PR TITLE
oneplus2: Remove Android.bp from root folder

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,4 +1,0 @@
-subdirs = [
-    "usb",
-    "light",
-]


### PR DESCRIPTION
Change-Id: I0bca4fe9e983d7641e474e4b872cadd7d22d20b4